### PR TITLE
LKK_DOMAIN changed to leankit.com

### DIFF
--- a/lib/leankitkanban/config.rb
+++ b/lib/leankitkanban/config.rb
@@ -6,7 +6,7 @@ module LeanKitKanban
     class << self
       attr_accessor :email, :password, :account
 
-      LKK_DOMAIN = "leankitkanban.com"
+      LKK_DOMAIN = "leankit.com"
       API_SUFFIX = "/Kanban/API"
 
       def validate

--- a/spec/leankitkanban/config_spec.rb
+++ b/spec/leankitkanban/config_spec.rb
@@ -41,7 +41,7 @@ describe LeanKitKanban::Config do
     end
 
     it "returns the domain including the account name" do
-      LeanKitKanban::Config.uri.should eql "http://#{TEST_ACCOUNT}.leankitkanban.com/Kanban/API"
+      LeanKitKanban::Config.uri.should eql "http://#{TEST_ACCOUNT}.leankit.com/Kanban/API"
     end
   end
 


### PR DESCRIPTION
It seems the leankitkanban.com domain no longer serves the API and has been moved to leankit.com.
Ref: 500 Service unavailable at leankitkanban.com domain
Ref: documentation https://support.leankit.com/hc/en-us/articles/204412623-Get-All-Boards